### PR TITLE
Feature/non backward comp

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,26 @@ puts manager[].class # =>  Hash
 puts manager.layers.class # =>  Hash
 ```
 
+:warning: Versions prior to `1.0.0` were trying to give an indifferent access to the merged hash for strings
+and symbols, ie `manager[:an_entry]` was giving the same result as `manager['an_entry']`.
+
+This is clearly wrong and not consistent everywhere.
+__Starting with version `1.0.0` this is no more the case__. Nevertheless a compatibility mode is provided for 
+applications relying on the legacy mechanism, you just need to do:
+
+```ruby
+require 'super_stack'
+SuperStack.set_compatibility_mode
+```
+or alternatively, you can do:
+
+```ruby
+require 'super_stack/old'
+```
+which is equivalent.
+
+
+
 ### Layers
 
 Layers are actually simple hashes that include the `SuperStack::LayerWrapper` module. Therefore you can create a layer by
@@ -142,4 +162,3 @@ The alternative is to set the policy at the layer level using `merge_policy=`
 
 [DMG]:      https://rubygems.org/gems/deep_merge        "Deep Merge gem"
 [DMGithub]: https://github.com/danielsdeleo/deep_merge  "Deep Merge Github project"
-

--- a/lib/super_stack.rb
+++ b/lib/super_stack.rb
@@ -4,3 +4,19 @@ require 'super_stack/layer_wrapper'
 require 'super_stack/layer'
 require 'super_stack/manager'
 
+module SuperStack
+
+  def self.set_compatibility_mode
+    require 'super_stack/compatibility/layer_wrapper'
+    require 'super_stack/compatibility/manager'
+
+    SuperStack::Manager.class_eval do
+      include SuperStack::Compatibility::Manager
+    end
+
+    SuperStack::LayerWrapper.module_eval do
+      include SuperStack::Compatibility::LayerWrapper
+    end
+  end
+
+end

--- a/lib/super_stack/compatibility/layer_wrapper.rb
+++ b/lib/super_stack/compatibility/layer_wrapper.rb
@@ -1,0 +1,23 @@
+module SuperStack
+  module Compatibility
+
+    module LayerWrapper
+
+      private
+
+      def load_from_yaml(file_name)
+        begin
+          self.replace Hash[YAML::load(File.open(file_name)).map { |k, v| [k.to_s, v] }]
+        rescue  NoMethodError => e
+          # Empty file...
+          raise "Invalid file '#{file_name}'" unless e.message =~ /false:FalseClass/
+        end
+        @file_name = file_name
+      end
+
+    end
+
+  end
+
+end
+

--- a/lib/super_stack/compatibility/manager.rb
+++ b/lib/super_stack/compatibility/manager.rb
@@ -1,0 +1,46 @@
+module SuperStack
+  module Compatibility
+
+    module Manager
+
+      def []=(key,value)
+        raise 'No write layer specified' if write_layer.nil?
+        write_layer[key.to_s] = value
+      end
+
+      def [](filter=nil)
+        layers = to_a
+        return [] if layers.empty?
+        layers.each { |layer| layer.reload if layer.source_auto_reload?}
+        first_layer = layers.shift
+        first_layer = first_layer.disabled? ? SuperStack::Layer.new : first_layer
+        res = layers.inject(first_layer) do |stack, layer|
+          if layer.disabled?
+            stack
+          else
+            policy_to_apply = layer.merge_policy.nil? ? default_merge_policy : layer.merge_policy
+            policy_to_apply.merge stack, stringify_keys(layer)
+          end
+        end
+        if filter.nil?
+          res.to_hash
+        else
+          res[filter]
+        end
+      end
+
+
+
+      private
+
+      def stringify_keys(hash)
+        hash.inject({}){|stringified_hash, (key, value)|
+          stringified_hash[key.to_s] = value
+          stringified_hash
+        }
+      end
+
+    end
+
+  end
+end

--- a/lib/super_stack/layer_wrapper.rb
+++ b/lib/super_stack/layer_wrapper.rb
@@ -76,10 +76,13 @@ module SuperStack
 
     private
 
+
+
+
     def load_from_yaml(file_name)
       begin
-        self.replace Hash[YAML::load(File.open(file_name)).map { |k, v| [k.to_s, v] }]
-
+        raw_content = File.open file_name
+        self.replace Hash[YAML::load(raw_content).map { |k, v| [k, v] }]
       rescue  NoMethodError => e
         # Empty file...
         raise "Invalid file '#{file_name}'" unless e.message =~ /false:FalseClass/

--- a/lib/super_stack/layer_wrapper.rb
+++ b/lib/super_stack/layer_wrapper.rb
@@ -74,18 +74,22 @@ module SuperStack
       hash.extend self
     end
 
+    def to_hash
+      # Trick to return a bare hash
+      {}.merge self
+    end
+
     private
 
 
-
-
     def load_from_yaml(file_name)
-      begin
-        raw_content = File.open file_name
-        self.replace Hash[YAML::load(raw_content).map { |k, v| [k, v] }]
-      rescue  NoMethodError => e
-        # Empty file...
-        raise "Invalid file '#{file_name}'" unless e.message =~ /false:FalseClass/
+      raw_content = File.read file_name
+      res = YAML.load raw_content
+      if res
+        self.replace Hash[res.map { |k, v| [k, v] }]
+      else
+        raise "Invalid file '#{file_name}'" unless raw_content.empty?
+        clear
       end
       @file_name = file_name
     end

--- a/lib/super_stack/layer_wrapper.rb
+++ b/lib/super_stack/layer_wrapper.rb
@@ -88,7 +88,7 @@ module SuperStack
       if res
         self.replace Hash[res.map { |k, v| [k, v] }]
       else
-        raise "Invalid file '#{file_name}'" unless raw_content.empty?
+        raise "Invalid file content for '#{file_name}'" unless raw_content.empty?
         clear
       end
       @file_name = file_name

--- a/lib/super_stack/manager.rb
+++ b/lib/super_stack/manager.rb
@@ -24,7 +24,7 @@ module SuperStack
 
     def []=(key,value)
       raise 'No write layer specified' if write_layer.nil?
-      write_layer[key.to_s] = value
+      write_layer[key] = value
     end
 
     def [](filter=nil)
@@ -38,14 +38,14 @@ module SuperStack
           stack
         else
           policy_to_apply = layer.merge_policy.nil? ? default_merge_policy : layer.merge_policy
-          policy_to_apply.merge stack, stringify_keys(layer)
+          policy_to_apply.merge stack, layer # stringify_keys(layer)
         end
       end
       if filter.nil?
         # Trick to return a bare hash
         {}.merge res
       else
-        res[filter.to_s]
+        res[filter]
       end
     end
 
@@ -102,12 +102,12 @@ module SuperStack
 
     private
 
-    def stringify_keys(hash)
-      hash.inject({}){|stringified_hash, (key, value)|
-        stringified_hash[key.to_s] = value
-        stringified_hash
-      }
-    end
+    # def stringify_keys(hash)
+    #   hash.inject({}){|stringified_hash, (key, value)|
+    #     stringified_hash[key.to_s] = value
+    #     stringified_hash
+    #   }
+    # end
 
 
     def get_existing_layer(layer_or_layer_name, error_message)

--- a/lib/super_stack/manager.rb
+++ b/lib/super_stack/manager.rb
@@ -42,8 +42,7 @@ module SuperStack
         end
       end
       if filter.nil?
-        # Trick to return a bare hash
-        {}.merge res
+        res.to_hash
       else
         res[filter]
       end

--- a/lib/super_stack/manager.rb
+++ b/lib/super_stack/manager.rb
@@ -38,7 +38,7 @@ module SuperStack
           stack
         else
           policy_to_apply = layer.merge_policy.nil? ? default_merge_policy : layer.merge_policy
-          policy_to_apply.merge stack, layer # stringify_keys(layer)
+          policy_to_apply.merge stack, layer
         end
       end
       if filter.nil?
@@ -100,13 +100,6 @@ module SuperStack
     end
 
     private
-
-    # def stringify_keys(hash)
-    #   hash.inject({}){|stringified_hash, (key, value)|
-    #     stringified_hash[key.to_s] = value
-    #     stringified_hash
-    #   }
-    # end
 
 
     def get_existing_layer(layer_or_layer_name, error_message)

--- a/lib/super_stack/old.rb
+++ b/lib/super_stack/old.rb
@@ -1,0 +1,3 @@
+require 'super_stack'
+
+SuperStack.set_compatibility_mode

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,7 @@
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 
 require 'super_stack'
+SuperStack.set_compatibility_mode
 
 
 def file_from_layer(layer_number)

--- a/test/layer_content_type_containing_an_array.yml
+++ b/test/layer_content_type_containing_an_array.yml
@@ -1,3 +1,4 @@
 - One
 - two
 - three
+- :four

--- a/test/stacked_layer_1.yml
+++ b/test/stacked_layer_1.yml
@@ -1,9 +1,9 @@
-layer: one
+:layer: one
 
-from_layer_1:
+:from_layer_1:
   stupid-data: stupid in one
 
-to-be-merged:
+:to-be-merged:
   name: from layer 1
   my-prop: property one
   my-array:

--- a/test/stacked_layer_2.yml
+++ b/test/stacked_layer_2.yml
@@ -1,9 +1,9 @@
-layer: two
+:layer: two
 
-from_layer_2:
+:from_layer_2:
   stupid-data: stupid in two
 
-to-be-merged:
+:to-be-merged:
   name: from layer 2
   my-prop: property two
   my-array:

--- a/test/stacked_layer_3.yml
+++ b/test/stacked_layer_3.yml
@@ -1,9 +1,9 @@
-layer: three
+:layer: three
 
-from_layer_3:
+:from_layer_3:
   stupid-data: stupid in three
 
-to-be-merged:
+:to-be-merged:
   name: from layer 3
   my-prop: property three
   my-array:

--- a/test/stacked_layer_4.yml
+++ b/test/stacked_layer_4.yml
@@ -1,9 +1,9 @@
-layer: four
+:layer: four
 
-from_layer_4:
+:from_layer_4:
   stupid-data: stupid in four
 
-to-be-merged:
+:to-be-merged:
   name: from layer 4
   my-prop: property four
   my-array:


### PR DESCRIPTION
This introduces non backward compatible changes to the library.
People that want to keep the old behaviour can:
- Keep on using the old 0.x versions
- Use the compatibility mode provided in the 1.x versions

The changes are around the fact that previously the library was trying to give indifferent access to the main hash using either symbols or strings. **This is no more the case !** Now the library is no more trying to modify your data, which is _probably_ a good thing...
